### PR TITLE
Laravel Backport

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 php:
   - 7.1
   - 7.2
+  - 7.3
 
 before_script:
   - phpenv config-rm xdebug.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ before_script:
   - phpenv config-rm xdebug.ini
   - travis_retry composer install --prefer-dist --no-interaction
 
-script: phpunit
+script: ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 This is an API for GuzzleHTTP. It aims to make using Guzzle a bit more clean and extends reusability.
 
 # Requirements
-* PHP 7.1 or higher
-* Laravel [5.5](https://laravel.com/docs/5.5) or [5.6](https://laravel.com/docs/5.6)
+* PHP 7.1 - PHP 7.2
+* Laravel [5.5](https://laravel.com/docs/5.5), [5.6](https://laravel.com/docs/5.6) or [5.7](https://laravel.com/docs/5.7)
 
 # Installation
 Via composer

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "libr",
   "license": "MIT",
   "require": {
-    "php": "7.1.*||7.2.*",
+    "php": ">=7.1",
     "guzzlehttp/guzzle": "^6.3",
     "illuminate/support": "5.5.*||5.6.*||5.7.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
   "type": "libr",
   "license": "MIT",
   "require": {
-    "php": ">=7.1",
+    "php": "7.1.*||7.2.*",
     "guzzlehttp/guzzle": "^6.3",
-    "illuminate/support": "5.5.*||5.6.*"
+    "illuminate/support": "5.5.*||5.6.*||5.7.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "7.0.*"
   },
   "prefer-stable": true,
   "minimum-stability": "stable",

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,11 +17,11 @@ class Client implements RequestInterface
     /** @var null|array */
     protected $body;
 
-    /** @var null|array */
-    protected $headers;
+    /** @var array */
+    protected $headers = [];
 
-    /** @var null|array */
-    protected $options;
+    /** @var array */
+    protected $options = [];
 
     /** @var string */
     protected $format = 'json';


### PR DESCRIPTION
Adds strict version requirements for Laravel 5.5-5.7, PHP 7.1 and up, as well as PHPUnit 7. This also fixes #3 where a later release of Guzzle requires empty header values to be an array, rather than a null value.