### PR TITLE
Laravel 5.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 dist: trusty
 
 php:
-  - 7.1
   - 7.2
   - 7.3
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 This is an API for GuzzleHTTP. It aims to make using Guzzle a bit more clean and extends reusability.
 
 # Requirements
-* PHP 7.1 - PHP 7.2
-* Laravel [5.5](https://laravel.com/docs/5.5), [5.6](https://laravel.com/docs/5.6) or [5.7](https://laravel.com/docs/5.7)
+* PHP 7.2 or newer
+* Laravel [5.8](https://laravel.com/docs/5.8) or newer
 
 # Installation
 Via composer

--- a/composer.json
+++ b/composer.json
@@ -4,12 +4,12 @@
   "type": "libr",
   "license": "MIT",
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.2",
     "guzzlehttp/guzzle": "^6.3",
-    "illuminate/support": "5.5.*||5.6.*||5.7.*"
+    "illuminate/support": ">=5.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.0.*"
+    "phpunit/phpunit": "8.0.*"
   },
   "prefer-stable": true,
   "minimum-stability": "stable",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
     "illuminate/support": ">=5.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "8.0.*"
+    "phpunit/phpunit": "8.0.*",
+    "dms/phpunit-arraysubset-asserts": ">=0.1.0"
   },
   "prefer-stable": true,
   "minimum-stability": "stable",

--- a/tests/GuzzleApiTest.php
+++ b/tests/GuzzleApiTest.php
@@ -1,10 +1,14 @@
 <?php
 
 use CmdrSharp\GuzzleApi\Client as GuzzleClient;
+use DMS\PHPUnitExtensions\ArraySubset\Assert;
+use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use PHPUnit\Framework\TestCase;
 
 class GuzzleApiTest extends TestCase
 {
+    use ArraySubsetAsserts;
+    
     /** @var GuzzleClient */
     protected $client;
 
@@ -22,7 +26,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asJson()->get()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'json' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -38,7 +42,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asJson()->request('get')->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'json' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -69,7 +73,7 @@ class GuzzleApiTest extends TestCase
     {
         $response = $this->client->to('anything?foo=bar&baz=qux')->get()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -84,7 +88,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asJson()->get()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'foo' => 'bar'
             ],
@@ -102,7 +106,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asJson()->post()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'json' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -121,7 +125,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asFormParams()->post()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'form' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -139,7 +143,7 @@ class GuzzleApiTest extends TestCase
             'Custom' => 'Header'
         ])->asJson()->get()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'headers' => [
                 'Custom' => 'Header'
             ]
@@ -153,7 +157,7 @@ class GuzzleApiTest extends TestCase
             'Custom' => 'Header'
         ])->asJson()->post()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'headers' => [
                 'Custom' => 'Header'
             ]
@@ -168,7 +172,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asJson()->patch()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'json' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -184,7 +188,7 @@ class GuzzleApiTest extends TestCase
             'baz' => 'qux'
         ])->asJson()->put()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'json' => [
                 'foo' => 'bar',
                 'baz' => 'qux'
@@ -197,7 +201,7 @@ class GuzzleApiTest extends TestCase
     {
         $response = $this->client->to('delete?id=1')->asJson()->delete()->getBody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'id' => 1
             ]
@@ -212,7 +216,7 @@ class GuzzleApiTest extends TestCase
             'bacon' => 'sandwich'
         ])->asJson()->post()->getbody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'foo' => 'bar'
             ],
@@ -231,7 +235,7 @@ class GuzzleApiTest extends TestCase
             'bacon' => 'sandwich'
         ])->asJson()->patch()->getbody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'foo' => 'bar'
             ],
@@ -250,7 +254,7 @@ class GuzzleApiTest extends TestCase
             'bacon' => 'sandwich'
         ])->asJson()->put()->getbody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'foo' => 'bar'
             ],
@@ -269,7 +273,7 @@ class GuzzleApiTest extends TestCase
             'bacon' => 'sandwich'
         ])->asJson()->delete()->getbody();
 
-        $this->assertArraySubset([
+        Assert::assertArraySubset([
             'args' => [
                 'foo' => 'bar'
             ],

--- a/tests/GuzzleApiTest.php
+++ b/tests/GuzzleApiTest.php
@@ -8,7 +8,7 @@ class GuzzleApiTest extends TestCase
     /** @var GuzzleClient */
     protected $client;
 
-    public function setUp()
+    public function setUp(): void
     {
         $client = new GuzzleClient();
         $this->client = $client->make('https://httpbin.org');

--- a/tests/GuzzleApiTest.php
+++ b/tests/GuzzleApiTest.php
@@ -65,7 +65,7 @@ class GuzzleApiTest extends TestCase
     function can_retrieve_the_raw_response_body()
     {
         $response = $this->client->to('robots.txt')->get()->getBody();
-        $this->assertContains('User-agent: *', (string)$response);
+        $this->assertStringContainsStringIgnoringCase('User-agent: *', (string)$response);
     }
 
     /** @test */


### PR DESCRIPTION
- Removes PHP 7.1 support
- Strictly requires PHPUnit 8
- Requires Laravel 5.8 or above
- New dev dependency to fix PHPUnit 9 deprecation warnings.